### PR TITLE
Add workshop examples as test cases

### DIFF
--- a/tests/workshop_PBP2X_Res_and_Sus_Amoxicillin.json
+++ b/tests/workshop_PBP2X_Res_and_Sus_Amoxicillin.json
@@ -1,0 +1,11 @@
+{
+  "p_value": 0.05,
+  "groups": [
+    "/olson@patricbrc.org/PATRIC-QA/applications/App-MetaCATS/PBP2x Susceptible Amox",
+    "/olson@patricbrc.org/PATRIC-QA/applications/App-MetaCATS/PBP2X Resistant Amoxicillin"
+  ],
+  "input_type": "groups",
+  "output_file": "workshop_pbp2x_res_and_sus_amoxicillin",
+  "alphabet": "aa",
+  "output_path": "/olson@patricbrc.org/PATRIC-QA/applications/App-MetaCATS"
+}

--- a/tests/workshop_pbp2x_res_vs_sus_metacats.json
+++ b/tests/workshop_pbp2x_res_vs_sus_metacats.json
@@ -1,0 +1,12 @@
+{
+  "output_file": "workshop_pbp2x_res_vs_sus_metacats",
+  "output_path": "/olson@patricbrc.org/PATRIC-QA/applications/App-MetaCATS",
+  "alphabet": "aa",
+  "p_value": 0.05,
+  "input_type": "groups",
+  "groups": [
+    "/olson@patricbrc.org/PATRIC-QA/applications/App-MetaCATS/Pbp2x private gene",
+    "/olson@patricbrc.org/PATRIC-QA/applications/App-MetaCATS/Susceptible Pbp2x",
+    "/olson@patricbrc.org/PATRIC-QA/applications/App-MetaCATS/Resistant Pbp2x"
+  ]
+}


### PR DESCRIPTION
  ## Summary
  - Adds 2 workshop QA test cases (PBP2X amoxicillin resistant/susceptible group comparisons) under tests/, pointed at the PATRIC-QA App-MetaCATS
  workspace for input/output.

  ## Test plan
  - [x] Ran each test case via appserv-start-app against the app service; both completed successfully (job IDs 23062086, 23062087).