### PR TITLE
Fix MetaCATS QA fixtures referencing inaccessible jsporter workspace

### DIFF
--- a/tests/auto_groups_formfill.json
+++ b/tests/auto_groups_formfill.json
@@ -1,6 +1,6 @@
 {
     "p_value": 0.05,
-    "output_path": "/jsporter@patricbrc.org/home/MetaCATS",
+    "output_path": "/olson@patricbrc.org/PATRIC-QA/applications/App-MetaCATS",
     "output_file": "formfill2",
     "year_ranges": "1998,1999-2005,2006",
     "alphabet": "aa",

--- a/tests/filename_whitespace_issue_675.json
+++ b/tests/filename_whitespace_issue_675.json
@@ -1,6 +1,6 @@
 {
     "p_value": 0.05,
-    "output_path": "/jsporter@patricbrc.org/home/MetaCATS",
+    "output_path": "/olson@patricbrc.org/PATRIC-QA/applications/App-MetaCATS",
     "output_file": "issue_675_metacats",
     "alignment_file": "/BVBRC@patricbrc.org/BVBRC Tests/MetaCATS/SARSCov2 Spike Protein - Nonhuman Mammals - MSA.afa",
     "group_file": "/BVBRC@patricbrc.org/BVBRC Tests/MetaCATS/spike_protein_nonhuman_mammal_metadata.tsv",

--- a/tests/windows_input.json
+++ b/tests/windows_input.json
@@ -1,9 +1,9 @@
 {
     "p_value": 0.05,
-    "output_path": "/jsporter@patricbrc.org/home/MetaCATS",
+    "output_path": "/olson@patricbrc.org/PATRIC-QA/applications/App-MetaCATS",
     "output_file": "windows_input",
-    "alignment_file": "/jsporter@patricbrc.org/JSP_debug/aniewiad1/11_nucleocapsid_align_nostop.fasta",
-    "group_file": "/jsporter@patricbrc.org/JSP_debug/aniewiad1/11_nucleocapsid_align_nostop.tsv",
+    "alignment_file": "/olson@patricbrc.org/PATRIC-QA/applications/App-MetaCATS/11_nucleocapsid_align_nostop.fasta",
+    "group_file": "/olson@patricbrc.org/PATRIC-QA/applications/App-MetaCATS/11_nucleocapsid_align_nostop.tsv",
     "alphabet": "na",
     "input_type": "files"
 }


### PR DESCRIPTION
## Summary

Three MetaCATS QA fixtures referenced jsporter's private workspace, which the QA runner can't read — the same class of problem as the MSA preflight failures (unreadable input causes `stat` to return `undef`).

- **`windows_input.json`** — `alignment_file` / `group_file` lived under `/jsporter@…/JSP_debug/aniewiad1/` (owned by `aniewiad1@bvbrc`, not globally readable), so the job would fail on input stat. The two data files were copied into the accessible QA area (via `p3-cp -A`) and the paths repointed.
- **`filename_whitespace_issue_675.json`**, **`auto_groups_formfill.json`** — their inputs were already accessible (`/BVBRC@…/BVBRC Tests/…` is globally readable; `auto_groups_formfill` uses inline auto-groups), but their `output_path` pointed at `/jsporter@…/home/MetaCATS`.

All three now resolve under `/olson@patricbrc.org/PATRIC-QA/applications/App-MetaCATS`. No `jsporter` references remain in the fixtures.

## Test plan
- All three fixtures validated as well-formed JSON.
- The two `windows_input` data files confirmed readable in the accessible QA area as the running user.
- Live `/vol` QA copies synced to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)